### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,7 @@ setup(name='GFSV2',     # This is the package name
          'ConfigParser',
          'argparse',
          'pydap',
-         'pycurl',
-         'logging'
+         'pycurl'
       ],
       scripts=['bin/GFSV2_bulk',
                'bin/GFSV2_get',


### PR DESCRIPTION
* remove logging module as it's part of python distributions and fails to reinstall on python3

```
File "/tmp/pip-install-suv5wdlg/logging/logging/__init__.py", line 618
        raise NotImplementedError, 'emit must be implemented '\
```